### PR TITLE
Update branch references from 'main' to 'master' in workflow files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - "package.json"
       - "CHANGELOG.md"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -3,7 +3,7 @@ name: Version Check
 on:
   pull_request:
     branches:
-      - main
+      - master
     paths:
       - "package.json"
       - "CHANGELOG.md"


### PR DESCRIPTION
Update workflow files to reflect the change in branch naming from 'main' to 'master'.